### PR TITLE
Drop extra `/`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-- 3.4
 - 3.5
 - 3.6
 

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -56,7 +56,7 @@ def _maybe_split_channel(channel):
     # strip trailing slashes
     channel = channel.strip('/')
 
-    default_url_base = "https://conda.anaconda.org/"
+    default_url_base = "https://conda.anaconda.org"
     url_suffix = "/{channel}/{platform}/{file_name}"
     if '://' not in channel:
         # assume we are being given a channel for anaconda.org


### PR DESCRIPTION
Adding this `/` results in not getting the CDN. As a consequence one has slower access and does not get patched repodata. Dropping this `/` fixes that issue.

cc @mike-wendt