### PR TITLE
Differential tarball tool

### DIFF
--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -85,11 +85,8 @@ def read_reference():
     """
     Read the "reference file" from disk and return its content as a dictionary.
     """
-    try:
-        with open(REFERENCE_PATH) as fi:
-            return json.load(fi)
-    except FileNotFoundError:
-        sys.exit('No such file: %s' % REFERENCE_PATH)
+    with open(REFERENCE_PATH) as fi:
+        return json.load(fi)
 
 
 def get_updates():
@@ -99,7 +96,10 @@ def get_updates():
     repository.  That is, the files which need to go into the differential
     tarball.
     """
-    d1 = read_reference()
+    try:
+        d1 = read_reference()
+    except FileNotFoundError:
+        no_reference()
     d2 = all_repodata()
     for repo_path, index2 in d2.items():
         index1 = d1.get(repo_path, {})
@@ -124,6 +124,13 @@ def tar_repo(outfile='update.tar', verbose=False):
     t.close()
     if verbose:
         print("Wrote: %s" % outfile)
+
+
+def no_reference():
+    sys.exit("""
+Error: no such file: %s
+Please use the --reference option before creating a differential tarball.
+    """ % REFERENCE_PATH)
 
 
 def main():

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -85,8 +85,14 @@ def read_reference():
     """
     Read the "reference file" from disk and return its content as a dictionary.
     """
-    with open(REFERENCE_PATH) as fi:
-        return json.load(fi)
+    try:
+        with open(REFERENCE_PATH) as fi:
+            return json.load(fi)
+    except FileNotFoundError:
+        sys.exit("""\
+Error: no such file: %s
+Please use the --reference option before creating a differential tarball.
+""" % REFERENCE_PATH)
 
 
 def get_updates():
@@ -96,10 +102,7 @@ def get_updates():
     repository.  That is, the files which need to go into the differential
     tarball.
     """
-    try:
-        d1 = read_reference()
-    except FileNotFoundError:
-        no_reference()
+    d1 = read_reference()
     d2 = all_repodata()
     for repo_path, index2 in d2.items():
         index1 = d1.get(repo_path, {})
@@ -124,13 +127,6 @@ def tar_repo(outfile='update.tar', verbose=False):
     t.close()
     if verbose:
         print("Wrote: %s" % outfile)
-
-
-def no_reference():
-    sys.exit("""
-Error: no such file: %s
-Please use the --reference option before creating a differential tarball.
-    """ % REFERENCE_PATH)
 
 
 def main():

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -127,66 +127,71 @@ def tar_repo(outfile='update.tar', verbose=False):
 
 
 def main():
-    from optparse import OptionParser
+    import argparse
 
-    p = OptionParser(usage="usage: %prog [options] MIRROR_DIRECTORY",
-                     description='create "differential" tarballs of a conda '
-                                 'mirror repository')
+    p = argparse.ArgumentParser(
+        description='create "differential" tarballs of a conda repository')
 
-    p.add_option('--create',
-                 action="store_true",
-                 help="create a differential tarball")
+    p.add_argument('repo_dir',
+                   nargs='?',
+                   action="store",
+                   metavar='REPOSITORY',
+                   help="path to repository directory")
 
-    p.add_option('--reference',
-                 action="store_true",
-                 help="create a reference point file and exit")
+    p.add_argument('--create',
+                   action="store_true",
+                   help="create differential tarball")
 
-    p.add_option('--show',
-                 action="store_true",
-                 help="show the files in respect to the latest reference "
-                      "point file (which would be included in the "
-                      "differential tarball) and exit")
+    p.add_argument('--reference',
+                   action="store_true",
+                   help="create a reference point file")
 
-    p.add_option('--verify',
-                 action="store_true",
-                 help="verify the mirror repository and exit")
+    p.add_argument('--show',
+                   action="store_true",
+                   help="show the files in respect to the latest reference "
+                        "point file (which would be included in the "
+                        "differential tarball)")
 
-    p.add_option('-v', '--verbose',
-                 action="store_true")
+    p.add_argument('--verify',
+                   action="store_true",
+                   help="verify the mirror repository and exit")
 
-    p.add_option('--version',
-                 action="store_true",
-                 help="print version and exit")
+    p.add_argument('-v', '--verbose',
+                   action="store_true")
 
-    opts, args = p.parse_args()
+    p.add_argument('--version',
+                   action="store_true",
+                   help="print version and exit")
 
-    if opts.version:
+    args = p.parse_args()
+
+    if args.version:
         from conda_mirror import __version__
         print('conda-mirror: %s' % __version__)
         return
 
-    if len(args) != 1:
-        p.error('exactly one argument is required, try -h')
+    if not args.repo_dir:
+        p.error('exactly one REPOSITORY is required, try -h')
 
     global MIRROR_DIR
-    MIRROR_DIR = abspath(args[0])
+    MIRROR_DIR = abspath(args.repo_dir)
     if not isdir(MIRROR_DIR):
         sys.exit("No such directory: %r" % MIRROR_DIR)
 
-    if opts.create:
-        tar_repo(verbose=opts.verbose)
+    if args.create:
+        tar_repo(verbose=args.verbose)
         return
 
-    if opts.verify:
+    if args.verify:
         verify_all_repos()
         return
 
-    if opts.show:
+    if args.show:
         for path in get_updates():
             print(path)
         return
 
-    if opts.reference:
+    if args.reference:
         write_reference()
         return
 

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -187,22 +187,19 @@ def main():
 
     if args.create:
         tar_repo(verbose=args.verbose)
-        return
 
-    if args.verify:
+    elif args.verify:
         verify_all_repos()
-        return
 
-    if args.show:
+    elif args.show:
         for path in get_updates():
             print(path)
-        return
 
-    if args.reference:
+    elif args.reference:
         write_reference()
-        return
 
-    print("Nothing done.")
+    else:
+        print("Nothing done.")
 
 
 if __name__ == '__main__':

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -106,19 +106,18 @@ def get_updates():
                 yield relpath(join(repo_path, fn), mirror_dir)
 
 
-def tar_repo(verbose=False):
+def tar_repo(outfile='update.tar', verbose=False):
     """
     Write the so-called differential tarball, see get_updates().
     """
-    fn = 'update.tar'
-    t = tarfile.open(fn, 'w')
+    t = tarfile.open(outfile, 'w')
     for f in get_updates():
         if verbose:
             print('adding: %s' % f)
         t.add(join(mirror_dir, f), f)
     t.close()
     if verbose:
-        print("Wrote: %s" % fn)
+        print("Wrote: %s" % outfile)
 
 
 def main():
@@ -169,7 +168,7 @@ def main():
         sys.exit("No such directory: %r" % mirror_dir)
 
     if opts.create:
-        tar_repo(opts.verbose)
+        tar_repo(verbose=opts.verbose)
         return
 
     if opts.verify:

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -9,6 +9,7 @@ from os.path import abspath, isdir, join, relpath
 mirror_dir = None
 reference_path = './reference.json'
 
+
 def md5_file(path):
     """
     Return the MD5 hashsum of the file given by `path` in hexadecimal

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -12,8 +12,8 @@ import tarfile
 from os.path import abspath, isdir, join, relpath
 
 
-mirror_dir = None
-reference_path = './reference.json'
+MIRROR_DIR = None
+REFERENCE_PATH = './reference.json'
 
 
 def md5_file(path):
@@ -33,10 +33,10 @@ def md5_file(path):
 
 def find_repos():
     """
-    Asssuming the global `mirror_dir` is set, iterate all sub-directories
+    Asssuming the global `MIRROR_DIR` is set, iterate all sub-directories
     which contain a repodata.json and repodata.json.bz2 file.
     """
-    for root, unused_dirs, files in os.walk(mirror_dir):
+    for root, unused_dirs, files in os.walk(MIRROR_DIR):
         if 'repodata.json' in files and 'repodata.json.bz2' in files:
             yield root
 
@@ -77,7 +77,7 @@ def write_reference():
     # make sure we have newline at the end
     if not data.endswith('\n'):
         data += '\n'
-    with open(reference_path, 'w') as fo:
+    with open(REFERENCE_PATH, 'w') as fo:
         fo.write(data)
 
 
@@ -86,10 +86,10 @@ def read_reference():
     Read the "reference file" from disk and return its content as a dictionary.
     """
     try:
-        with open(reference_path) as fi:
+        with open(REFERENCE_PATH) as fi:
             return json.load(fi)
     except FileNotFoundError:
-        sys.exit('No such file: %s' % reference_path)
+        sys.exit('No such file: %s' % REFERENCE_PATH)
 
 
 def get_updates():
@@ -105,11 +105,11 @@ def get_updates():
         index1 = d1.get(repo_path, {})
         if index1 != index2:
             for fn in 'repodata.json', 'repodata.json.bz2':
-                yield relpath(join(repo_path, fn), mirror_dir)
+                yield relpath(join(repo_path, fn), MIRROR_DIR)
         for fn, info2 in index2.items():
             info1 = index1.get(fn, {})
             if info1.get('md5') != info2['md5']:
-                yield relpath(join(repo_path, fn), mirror_dir)
+                yield relpath(join(repo_path, fn), MIRROR_DIR)
 
 
 def tar_repo(outfile='update.tar', verbose=False):
@@ -120,7 +120,7 @@ def tar_repo(outfile='update.tar', verbose=False):
     for f in get_updates():
         if verbose:
             print('adding: %s' % f)
-        t.add(join(mirror_dir, f), f)
+        t.add(join(MIRROR_DIR, f), f)
     t.close()
     if verbose:
         print("Wrote: %s" % outfile)
@@ -168,10 +168,10 @@ def main():
     if len(args) != 1:
         p.error('exactly one argument is required, try -h')
 
-    global mirror_dir
-    mirror_dir = abspath(args[0])
-    if not isdir(mirror_dir):
-        sys.exit("No such directory: %r" % mirror_dir)
+    global MIRROR_DIR
+    MIRROR_DIR = abspath(args[0])
+    if not isdir(MIRROR_DIR):
+        sys.exit("No such directory: %r" % MIRROR_DIR)
 
     if opts.create:
         tar_repo(verbose=opts.verbose)

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -1,3 +1,9 @@
+"""
+Implementation of the conda-diff-tar command, a tools which allows creating
+differential tarballs of a (usually mirrored) conda repository.  The resulting
+tarball can be used to update a copy of the mirror on a remote (air-gapped)
+system, without having to copy the entire conda repository.
+"""
 import os
 import sys
 import json

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -1,0 +1,191 @@
+import os
+import sys
+import json
+import hashlib
+import tarfile
+from os.path import abspath, isdir, join, relpath
+
+
+mirror_dir = None
+reference_path = './reference.json'
+
+def md5_file(path):
+    """
+    Return the MD5 hashsum of the file given by `path` in hexadecimal
+    representation.
+    """
+    h = hashlib.new('md5')
+    with open(path, 'rb') as fi:
+        while 1:
+            chunk = fi.read(262144)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def find_repos():
+    """
+    Asssuming the global `mirror_dir` is set, iterate all sub-directories
+    which contain a repodata.json and repodata.json.bz2 file.
+    """
+    for root, unused_dirs, files in os.walk(mirror_dir):
+        if 'repodata.json' in files and 'repodata.json.bz2' in files:
+            yield root
+
+
+def all_repodata():
+    """
+    Return a dictionary mapping all repository sub-directories to the conda
+    package list as respresented by the 'packages' field in repodata.json.
+    """
+    d = {}
+    for repo_path in find_repos():
+        with open(join(repo_path, 'repodata.json')) as fi:
+            index = json.load(fi)['packages']
+        d[repo_path] = index
+    return d
+
+
+def verify_all_repos():
+    """
+    Verify all the MD5 sum of all conda packages listed in all repodata.json
+    files in the repository.
+    """
+    d = all_repodata()
+    for repo_path, index in d.items():
+        for fn, info in index.items():
+            path = join(repo_path, fn)
+            if info['md5'] == md5_file(path):
+                continue
+            print('MD5 mismatch: %s' % path)
+
+
+def write_reference():
+    """
+    Write the "reference file", which is a collection of the content of all
+    repodata.json files.
+    """
+    data = json.dumps(all_repodata(), indent=2, sort_keys=True)
+    # make sure we have newline at the end
+    if not data.endswith('\n'):
+        data += '\n'
+    with open(reference_path, 'w') as fo:
+        fo.write(data)
+
+
+def read_reference():
+    """
+    Read the "reference file" from disk and return its content as a dictionary.
+    """
+    try:
+        with open(reference_path) as fi:
+            return json.load(fi)
+    except FileNotFoundError:
+        sys.exit('No such file: %s' % reference_path)
+
+
+def get_updates():
+    """
+    Compare the "reference file" to the actual the repository (all the
+    repodata.json files) and iterate the new and updates files in the
+    repository.  That is, the files which need to go into the differential
+    tarball.
+    """
+    d1 = read_reference()
+    d2 = all_repodata()
+    for repo_path, index2 in d2.items():
+        index1 = d1.get(repo_path, {})
+        if index1 != index2:
+            for fn in 'repodata.json', 'repodata.json.bz2':
+                yield relpath(join(repo_path, fn), mirror_dir)
+        for fn, info2 in index2.items():
+            info1 = index1.get(fn, {})
+            if info1.get('md5') != info2['md5']:
+                yield relpath(join(repo_path, fn), mirror_dir)
+
+
+def tar_repo(verbose=False):
+    """
+    Write the so-called differential tarball, see get_updates().
+    """
+    fn = 'update.tar'
+    t = tarfile.open(fn, 'w')
+    for f in get_updates():
+        if verbose:
+            print('adding: %s' % f)
+        t.add(join(mirror_dir, f), f)
+    t.close()
+    if verbose:
+        print("Wrote: %s" % fn)
+
+
+def main():
+    from optparse import OptionParser
+
+    p = OptionParser(usage="usage: %prog [options] MIRROR_DIRECTORY",
+                     description='create "differential" tarballs of a conda '
+                                 'mirror repository')
+
+    p.add_option('--create',
+                 action="store_true",
+                 help="create a differential tarball")
+
+    p.add_option('--reference',
+                 action="store_true",
+                 help="create a reference point file and exit")
+
+    p.add_option('--show',
+                 action="store_true",
+                 help="show the files in respect to the latest reference "
+                      "point file (which would be included in the "
+                      "differential tarball) and exit")
+
+    p.add_option('--verify',
+                 action="store_true",
+                 help="verify the mirror repository and exit")
+
+    p.add_option('-v', '--verbose',
+                 action="store_true")
+
+    p.add_option('--version',
+                 action="store_true",
+                 help="print version and exit")
+
+    opts, args = p.parse_args()
+
+    if opts.version:
+        from conda_mirror import __version__
+        print('conda-mirror: %s' % __version__)
+        return
+
+    if len(args) != 1:
+        p.error('exactly one argument is required, try -h')
+
+    global mirror_dir
+    mirror_dir = abspath(args[0])
+    if not isdir(mirror_dir):
+        sys.exit("No such directory: %r" % mirror_dir)
+
+    if opts.create:
+        tar_repo(opts.verbose)
+        return
+
+    if opts.verify:
+        verify_all_repos()
+        return
+
+    if opts.show:
+        for path in get_updates():
+            print(path)
+        return
+
+    if opts.reference:
+        write_reference()
+        return
+
+    print("Nothing done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/diff-tar.md
+++ b/diff-tar.md
@@ -1,0 +1,63 @@
+Create differential tarballs
+============================
+
+This tools allows you to create differential tarballs of a (usually
+mirrored) conda repository.  The resulting tarball can be used to update
+a copy of the mirror on a remote (air-gapped) system, without having to
+copy the entire conda repository.  The workflow is a follows:
+
+  1. we assume that the remote and local repository are in sync
+  2. create a `reference.json` file of the local repository
+  3. update the local repository using `conda-mirror` or some other tools
+  4. create the "differential" tarball
+  5. move the differential tarball to the remote machine, and unpack it
+  6. now that the remote repository is up-to-date, we should create a new
+     `reference.json` on the local machine.  That is, step 2
+
+
+Notes:
+------
+
+The file `reference.json` is a collection of all `repodata.json`
+files (`linux-64`, `win-32`, `noarch`, etc.) of the local repository.
+It is created in order to compare a future state of the repository to the
+state of the repository when `reference.json` it was created.
+
+The differential tarball contains files which either have been updated (such
+as `repodata.json`) or new files (new conda packages).  It is meant to be
+unpacked on top of the existing mirror on the remote machine by:
+
+    cd <repository>
+    tar xf update.tar
+    # or y using tar's -C option from any directory
+    tar xf update.tar -C <repository>
+
+
+Example:
+--------
+
+In this example we assume that a conda mirror is located in `./repo`.
+Create `reference.json`:
+
+    conda-diff-tar --reference ./repo
+
+Show the files in respect to the latest reference point file (which would be
+included in the differential tarball).  Since we just created the reference
+file, we don't expect any output:
+
+    conda-diff-tar --show ./repo
+
+Now, we can update the mirror:
+
+    conda-mirror --upstream-channel conda-forge --target-directory ./repo ...
+
+Create the actual differential tarball:
+
+    $ conda-diff-tar --create ./repo
+    Wrote: update.tar
+    $ tar tf update.tar
+    noarch/repodata.json
+    noarch/repodata.json.bz2
+    noarch/ablog-0.9.2-py_0.tar.bz2
+    noarch/aws-amicleaner-0.2.2-py_0.tar.bz2
+    ...

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            'conda-mirror = conda_mirror.conda_mirror:cli'
+            'conda-mirror = conda_mirror.conda_mirror:cli',
+            'conda-diff-tar = conda_mirror.diff_tar:main',
         ]
     }
 )

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -77,6 +77,7 @@ class DiffTarTests(unittest.TestCase):
         self.create_test_repo()
         tarball = join(self.tmpdir, 'up.tar')
         dt.write_reference()
+        self.create_test_repo('win-32')
         dt.tar_repo(tarball)
         self.assertTrue(isfile(tarball))
 

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -3,7 +3,7 @@ import json
 import shutil
 import unittest
 import tempfile
-from os.path import join
+from os.path import isfile, join
 
 import conda_mirror.diff_tar as dt
 
@@ -65,6 +65,13 @@ class DiffTarTests(unittest.TestCase):
         self.create_test_repo()
         dt.write_reference()
         self.assertEqual(list(dt.get_updates()), [])
+
+    def test_tar_repo(self):
+        self.create_test_repo()
+        tarball = join(self.tmpdir, 'up.tar')
+        dt.write_reference()
+        dt.tar_repo(tarball)
+        self.assertTrue(isfile(tarball))
 
 
 if __name__ == '__main__':

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -21,11 +21,13 @@ def tmpdir():
     yield tmpdir
     shutil.rmtree(tmpdir)
 
+
 def test_md5_file(tmpdir):
     tmpfile = join(tmpdir, 'testfile')
     with open(tmpfile, 'wb') as fo:
         fo.write(b'A\n')
     assert dt.md5_file(tmpfile) == 'bf072e9119077b4e76437a93986787ef'
+
 
 def create_test_repo(subdirname='linux-64'):
     subdir = join(dt.MIRROR_DIR, subdirname)
@@ -37,9 +39,11 @@ def create_test_repo(subdirname='linux-64'):
         with open(join(subdir, fn), 'wb') as fo:
             pass
 
+
 def test_find_repos(tmpdir):
     create_test_repo()
     assert list(dt.find_repos()) == [join(dt.MIRROR_DIR, 'linux-64')]
+
 
 def test_all_repodata_repos(tmpdir):
     create_test_repo()
@@ -47,9 +51,11 @@ def test_all_repodata_repos(tmpdir):
     assert d[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
         EMPTY_MD5
 
+
 def test_verify_all_repos(tmpdir):
     create_test_repo()
     dt.verify_all_repos()
+
 
 def test_write_and_read_reference(tmpdir):
     create_test_repo()
@@ -57,6 +63,7 @@ def test_write_and_read_reference(tmpdir):
     ref = dt.read_reference()
     assert ref[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
         EMPTY_MD5
+
 
 def test_get_updates(tmpdir):
     create_test_repo()
@@ -69,6 +76,7 @@ def test_get_updates(tmpdir):
                    'win-32/repodata.json',
                    'win-32/repodata.json.bz2']
 
+
 def test_tar_repo(tmpdir):
     create_test_repo()
     tarball = join(tmpdir, 'up.tar')
@@ -77,14 +85,17 @@ def test_tar_repo(tmpdir):
     dt.tar_repo(tarball)
     assert isfile(tarball)
 
+
 def run_with_args(args):
     old_args = list(sys.argv)
     sys.argv = ['conda-diff-tar'] + args
     dt.main()
     sys.argv = old_args
 
+
 def test_version():
     run_with_args(['--version'])
+
 
 def test_misc(tmpdir):
     create_test_repo()

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 import shutil
 import unittest
@@ -80,6 +81,24 @@ class DiffTarTests(unittest.TestCase):
         self.create_test_repo('win-32')
         dt.tar_repo(tarball)
         self.assertTrue(isfile(tarball))
+
+    def run_with_args(self, args):
+        old_args = list(sys.argv)
+        sys.argv = ['conda-diff-tar'] + args
+        dt.main()
+        sys.argv = old_args
+
+    def test_version(self):
+        self.run_with_args(['--version'])
+
+    def test_misc(self):
+        self.create_test_repo()
+        self.run_with_args(['--reference', dt.mirror_dir])
+        self.assertTrue(isfile(dt.reference_path))
+        self.create_test_repo('win-32')
+        self.run_with_args(['--show', dt.mirror_dir])
+        self.run_with_args(['--create', '--verbose', dt.mirror_dir])
+        self.run_with_args(['--verify', dt.mirror_dir])
 
 
 if __name__ == '__main__':

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -2,9 +2,10 @@ import os
 import sys
 import json
 import shutil
-import unittest
 import tempfile
 from os.path import isfile, join
+
+import pytest
 
 import conda_mirror.diff_tar as dt
 
@@ -12,95 +13,85 @@ import conda_mirror.diff_tar as dt
 EMPTY_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
 
 
-class DiffTarTests(unittest.TestCase):
+@pytest.fixture
+def tmpdir():
+    tmpdir = tempfile.mkdtemp()
+    dt.MIRROR_DIR = join(tmpdir, 'repo')
+    dt.REFERENCE_PATH = join(tmpdir, 'reference.json')
+    yield tmpdir
+    shutil.rmtree(tmpdir)
 
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-        dt.MIRROR_DIR = join(self.tmpdir, 'repo')
-        dt.REFERENCE_PATH = join(self.tmpdir, 'reference.json')
+def test_md5_file(tmpdir):
+    tmpfile = join(tmpdir, 'testfile')
+    with open(tmpfile, 'wb') as fo:
+        fo.write(b'A\n')
+    assert dt.md5_file(tmpfile) == 'bf072e9119077b4e76437a93986787ef'
 
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+def create_test_repo(subdirname='linux-64'):
+    subdir = join(dt.MIRROR_DIR, subdirname)
+    os.makedirs(subdir)
+    with open(join(subdir, 'repodata.json'), 'w') as fo:
+        fo.write(json.dumps({'packages':
+                             {'a-1.0-0.tar.bz2': {'md5': EMPTY_MD5}}}))
+    for fn in 'repodata.json.bz2', 'a-1.0-0.tar.bz2':
+        with open(join(subdir, fn), 'wb') as fo:
+            pass
 
-    def test_md5_file(self):
-        tmpfile = join(self.tmpdir, 'testfile')
-        with open(tmpfile, 'wb') as fo:
-            fo.write(b'A\n')
-        self.assertEqual(dt.md5_file(tmpfile),
-                         'bf072e9119077b4e76437a93986787ef')
+def test_find_repos(tmpdir):
+    create_test_repo()
+    assert list(dt.find_repos()) == [join(dt.MIRROR_DIR, 'linux-64')]
 
-    def create_test_repo(self, subdirname='linux-64'):
-        subdir = join(dt.MIRROR_DIR, subdirname)
-        os.makedirs(subdir)
-        with open(join(subdir, 'repodata.json'), 'w') as fo:
-            fo.write(json.dumps({'packages':
-                                 {'a-1.0-0.tar.bz2': {'md5': EMPTY_MD5}}}))
-        for fn in 'repodata.json.bz2', 'a-1.0-0.tar.bz2':
-            with open(join(subdir, fn), 'wb') as fo:
-                pass
+def test_all_repodata_repos(tmpdir):
+    create_test_repo()
+    d = dt.all_repodata()
+    assert d[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
+        EMPTY_MD5
 
-    def test_find_repos(self):
-        self.create_test_repo()
-        self.assertEqual(list(dt.find_repos()),
-                         [join(dt.MIRROR_DIR, 'linux-64')])
+def test_verify_all_repos(tmpdir):
+    create_test_repo()
+    dt.verify_all_repos()
 
-    def test_all_repodata_repos(self):
-        self.create_test_repo()
-        d = dt.all_repodata()
-        self.assertEqual(
-            d[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
-            EMPTY_MD5)
+def test_write_and_read_reference(tmpdir):
+    create_test_repo()
+    dt.write_reference()
+    ref = dt.read_reference()
+    assert ref[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
+        EMPTY_MD5
 
-    def test_verify_all_repos(self):
-        self.create_test_repo()
-        dt.verify_all_repos()
+def test_get_updates(tmpdir):
+    create_test_repo()
+    dt.write_reference()
+    assert list(dt.get_updates()) == []
 
-    def test_write_and_read_reference(self):
-        self.create_test_repo()
-        dt.write_reference()
-        ref = dt.read_reference()
-        self.assertEqual(
-            ref[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
-            EMPTY_MD5)
+    create_test_repo('win-32')
+    lst = sorted(dt.get_updates())
+    assert lst == ['win-32/a-1.0-0.tar.bz2',
+                   'win-32/repodata.json',
+                   'win-32/repodata.json.bz2']
 
-    def test_get_updates(self):
-        self.create_test_repo()
-        dt.write_reference()
-        self.assertEqual(list(dt.get_updates()), [])
+def test_tar_repo(tmpdir):
+    create_test_repo()
+    tarball = join(tmpdir, 'up.tar')
+    dt.write_reference()
+    create_test_repo('win-32')
+    dt.tar_repo(tarball)
+    assert isfile(tarball)
 
-        self.create_test_repo('win-32')
-        lst = sorted(dt.get_updates())
-        self.assertEqual(lst, ['win-32/a-1.0-0.tar.bz2',
-                               'win-32/repodata.json',
-                               'win-32/repodata.json.bz2'])
+def run_with_args(args):
+    old_args = list(sys.argv)
+    sys.argv = ['conda-diff-tar'] + args
+    dt.main()
+    sys.argv = old_args
 
-    def test_tar_repo(self):
-        self.create_test_repo()
-        tarball = join(self.tmpdir, 'up.tar')
-        dt.write_reference()
-        self.create_test_repo('win-32')
-        dt.tar_repo(tarball)
-        self.assertTrue(isfile(tarball))
+def test_version():
+    run_with_args(['--version'])
 
-    def run_with_args(self, args):
-        old_args = list(sys.argv)
-        sys.argv = ['conda-diff-tar'] + args
-        dt.main()
-        sys.argv = old_args
-
-    def test_version(self):
-        self.run_with_args(['--version'])
-
-    def test_misc(self):
-        self.create_test_repo()
-        self.run_with_args(['--reference', dt.MIRROR_DIR])
-        self.assertTrue(isfile(dt.REFERENCE_PATH))
-        self.create_test_repo('win-32')
-        self.run_with_args(['--show', dt.MIRROR_DIR])
-        self.run_with_args(['--create', '--verbose', dt.MIRROR_DIR])
-        self.run_with_args(['--verify', dt.MIRROR_DIR])
-        self.run_with_args([dt.MIRROR_DIR])  # do nothing
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_misc(tmpdir):
+    create_test_repo()
+    run_with_args(['--reference', dt.MIRROR_DIR])
+    assert isfile(dt.REFERENCE_PATH)
+    create_test_repo('win-32')
+    run_with_args(['--show', dt.MIRROR_DIR])
+    run_with_args(['--create', '--verbose', dt.MIRROR_DIR])
+    run_with_args(['--verify', dt.MIRROR_DIR])
+    run_with_args([dt.MIRROR_DIR])  # do nothing

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -99,6 +99,7 @@ class DiffTarTests(unittest.TestCase):
         self.run_with_args(['--show', dt.mirror_dir])
         self.run_with_args(['--create', '--verbose', dt.mirror_dir])
         self.run_with_args(['--verify', dt.mirror_dir])
+        self.run_with_args([dt.mirror_dir])  # do nothing
 
 
 if __name__ == '__main__':

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -16,7 +16,7 @@ EMPTY_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
 @pytest.fixture
 def tmpdir():
     tmpdir = tempfile.mkdtemp()
-    dt.MIRROR_DIR = join(tmpdir, 'repo')
+    dt.mirror_dir = join(tmpdir, 'repo')
     dt.REFERENCE_PATH = join(tmpdir, 'reference.json')
     yield tmpdir
     shutil.rmtree(tmpdir)
@@ -30,7 +30,7 @@ def test_md5_file(tmpdir):
 
 
 def create_test_repo(subdirname='linux-64'):
-    subdir = join(dt.MIRROR_DIR, subdirname)
+    subdir = join(dt.mirror_dir, subdirname)
     os.makedirs(subdir)
     with open(join(subdir, 'repodata.json'), 'w') as fo:
         fo.write(json.dumps({'packages':
@@ -42,36 +42,37 @@ def create_test_repo(subdirname='linux-64'):
 
 def test_find_repos(tmpdir):
     create_test_repo()
-    assert list(dt.find_repos()) == [join(dt.MIRROR_DIR, 'linux-64')]
+    assert list(dt.find_repos(dt.mirror_dir)) == \
+        [join(dt.mirror_dir, 'linux-64')]
 
 
 def test_all_repodata_repos(tmpdir):
     create_test_repo()
-    d = dt.all_repodata()
-    assert d[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
+    d = dt.all_repodata(dt.mirror_dir)
+    assert d[join(dt.mirror_dir, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
         EMPTY_MD5
 
 
 def test_verify_all_repos(tmpdir):
     create_test_repo()
-    dt.verify_all_repos()
+    dt.verify_all_repos(dt.mirror_dir)
 
 
 def test_write_and_read_reference(tmpdir):
     create_test_repo()
-    dt.write_reference()
+    dt.write_reference(join(tmpdir, 'repo'))
     ref = dt.read_reference()
-    assert ref[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
+    assert ref[join(dt.mirror_dir, 'linux-64')]['a-1.0-0.tar.bz2']['md5'] == \
         EMPTY_MD5
 
 
 def test_get_updates(tmpdir):
     create_test_repo()
-    dt.write_reference()
-    assert list(dt.get_updates()) == []
+    dt.write_reference(join(tmpdir, 'repo'))
+    assert list(dt.get_updates(dt.mirror_dir)) == []
 
     create_test_repo('win-32')
-    lst = sorted(dt.get_updates())
+    lst = sorted(dt.get_updates(dt.mirror_dir))
     assert lst == ['win-32/a-1.0-0.tar.bz2',
                    'win-32/repodata.json',
                    'win-32/repodata.json.bz2']
@@ -80,9 +81,9 @@ def test_get_updates(tmpdir):
 def test_tar_repo(tmpdir):
     create_test_repo()
     tarball = join(tmpdir, 'up.tar')
-    dt.write_reference()
+    dt.write_reference(dt.mirror_dir)
     create_test_repo('win-32')
-    dt.tar_repo(tarball)
+    dt.tar_repo(dt.mirror_dir, tarball)
     assert isfile(tarball)
 
 
@@ -99,10 +100,10 @@ def test_version():
 
 def test_misc(tmpdir):
     create_test_repo()
-    run_with_args(['--reference', dt.MIRROR_DIR])
+    run_with_args(['--reference', dt.mirror_dir])
     assert isfile(dt.REFERENCE_PATH)
     create_test_repo('win-32')
-    run_with_args(['--show', dt.MIRROR_DIR])
-    run_with_args(['--create', '--verbose', dt.MIRROR_DIR])
-    run_with_args(['--verify', dt.MIRROR_DIR])
-    run_with_args([dt.MIRROR_DIR])  # do nothing
+    run_with_args(['--show', dt.mirror_dir])
+    run_with_args(['--create', '--verbose', dt.mirror_dir])
+    run_with_args(['--verify', dt.mirror_dir])
+    run_with_args([dt.mirror_dir])  # do nothing

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -16,8 +16,8 @@ class DiffTarTests(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
-        dt.mirror_dir = join(self.tmpdir, 'repo')
-        dt.reference_path = join(self.tmpdir, 'reference.json')
+        dt.MIRROR_DIR = join(self.tmpdir, 'repo')
+        dt.REFERENCE_PATH = join(self.tmpdir, 'reference.json')
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
@@ -30,7 +30,7 @@ class DiffTarTests(unittest.TestCase):
                          'bf072e9119077b4e76437a93986787ef')
 
     def create_test_repo(self, subdirname='linux-64'):
-        subdir = join(dt.mirror_dir, subdirname)
+        subdir = join(dt.MIRROR_DIR, subdirname)
         os.makedirs(subdir)
         with open(join(subdir, 'repodata.json'), 'w') as fo:
             fo.write(json.dumps({'packages':
@@ -42,13 +42,13 @@ class DiffTarTests(unittest.TestCase):
     def test_find_repos(self):
         self.create_test_repo()
         self.assertEqual(list(dt.find_repos()),
-                         [join(dt.mirror_dir, 'linux-64')])
+                         [join(dt.MIRROR_DIR, 'linux-64')])
 
     def test_all_repodata_repos(self):
         self.create_test_repo()
         d = dt.all_repodata()
         self.assertEqual(
-            d[join(dt.mirror_dir, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
+            d[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
             EMPTY_MD5)
 
     def test_verify_all_repos(self):
@@ -60,7 +60,7 @@ class DiffTarTests(unittest.TestCase):
         dt.write_reference()
         ref = dt.read_reference()
         self.assertEqual(
-            ref[join(dt.mirror_dir, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
+            ref[join(dt.MIRROR_DIR, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
             EMPTY_MD5)
 
     def test_get_updates(self):
@@ -93,13 +93,13 @@ class DiffTarTests(unittest.TestCase):
 
     def test_misc(self):
         self.create_test_repo()
-        self.run_with_args(['--reference', dt.mirror_dir])
-        self.assertTrue(isfile(dt.reference_path))
+        self.run_with_args(['--reference', dt.MIRROR_DIR])
+        self.assertTrue(isfile(dt.REFERENCE_PATH))
         self.create_test_repo('win-32')
-        self.run_with_args(['--show', dt.mirror_dir])
-        self.run_with_args(['--create', '--verbose', dt.mirror_dir])
-        self.run_with_args(['--verify', dt.mirror_dir])
-        self.run_with_args([dt.mirror_dir])  # do nothing
+        self.run_with_args(['--show', dt.MIRROR_DIR])
+        self.run_with_args(['--create', '--verbose', dt.MIRROR_DIR])
+        self.run_with_args(['--verify', dt.MIRROR_DIR])
+        self.run_with_args([dt.MIRROR_DIR])  # do nothing
 
 
 if __name__ == '__main__':

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -24,8 +24,9 @@ class DiffTarTests(unittest.TestCase):
     def test_md5_file(self):
         tmpfile = join(self.tmpdir, 'testfile')
         with open(tmpfile, 'wb') as fo:
-            fo.write(b'')
-        self.assertEqual(dt.md5_file(tmpfile), EMPTY_MD5)
+            fo.write(b'A\n')
+        self.assertEqual(dt.md5_file(tmpfile),
+                         'bf072e9119077b4e76437a93986787ef')
 
     def create_test_repo(self):
         subdir = join(dt.mirror_dir, 'linux-aarch64')

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -1,0 +1,71 @@
+import os
+import json
+import shutil
+import unittest
+import tempfile
+from os.path import join
+
+import conda_mirror.diff_tar as dt
+
+
+EMPTY_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
+
+
+class DiffTarTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        dt.mirror_dir = join(self.tmpdir, 'repo')
+        dt.reference_path = join(self.tmpdir, 'reference.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_md5_file(self):
+        tmpfile = join(self.tmpdir, 'testfile')
+        with open(tmpfile, 'wb') as fo:
+            fo.write(b'')
+        self.assertEqual(dt.md5_file(tmpfile), EMPTY_MD5)
+
+    def create_test_repo(self):
+        subdir = join(dt.mirror_dir, 'linux-aarch64')
+        os.makedirs(subdir)
+        with open(join(subdir, 'repodata.json'), 'w') as fo:
+            fo.write(json.dumps({'packages':
+                                 {'a-1.0-0.tar.bz2': {'md5': EMPTY_MD5}}}))
+        for fn in 'repodata.json.bz2', 'a-1.0-0.tar.bz2':
+            with open(join(subdir, fn), 'wb') as fo:
+                pass
+
+    def test_find_repos(self):
+        self.create_test_repo()
+        self.assertEqual(list(dt.find_repos()),
+                         [join(dt.mirror_dir, 'linux-aarch64')])
+
+    def test_all_repodata_repos(self):
+        self.create_test_repo()
+        d = dt.all_repodata()
+        self.assertEqual(
+            d[join(dt.mirror_dir, 'linux-aarch64')]['a-1.0-0.tar.bz2']['md5'],
+            EMPTY_MD5)
+
+    def test_verify_all_repos(self):
+        self.create_test_repo()
+        dt.verify_all_repos()
+
+    def test_write_and_read_reference(self):
+        self.create_test_repo()
+        dt.write_reference()
+        ref = dt.read_reference()
+        self.assertEqual(
+            ref[join(dt.mirror_dir, 'linux-aarch64')]['a-1.0-0.tar.bz2']['md5'],
+            EMPTY_MD5)
+
+    def test_get_updates(self):
+        self.create_test_repo()
+        dt.write_reference()
+        self.assertEqual(list(dt.get_updates()), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -28,8 +28,8 @@ class DiffTarTests(unittest.TestCase):
         self.assertEqual(dt.md5_file(tmpfile),
                          'bf072e9119077b4e76437a93986787ef')
 
-    def create_test_repo(self):
-        subdir = join(dt.mirror_dir, 'linux-aarch64')
+    def create_test_repo(self, subdirname='linux-64'):
+        subdir = join(dt.mirror_dir, subdirname)
         os.makedirs(subdir)
         with open(join(subdir, 'repodata.json'), 'w') as fo:
             fo.write(json.dumps({'packages':
@@ -41,13 +41,13 @@ class DiffTarTests(unittest.TestCase):
     def test_find_repos(self):
         self.create_test_repo()
         self.assertEqual(list(dt.find_repos()),
-                         [join(dt.mirror_dir, 'linux-aarch64')])
+                         [join(dt.mirror_dir, 'linux-64')])
 
     def test_all_repodata_repos(self):
         self.create_test_repo()
         d = dt.all_repodata()
         self.assertEqual(
-            d[join(dt.mirror_dir, 'linux-aarch64')]['a-1.0-0.tar.bz2']['md5'],
+            d[join(dt.mirror_dir, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
             EMPTY_MD5)
 
     def test_verify_all_repos(self):
@@ -59,13 +59,19 @@ class DiffTarTests(unittest.TestCase):
         dt.write_reference()
         ref = dt.read_reference()
         self.assertEqual(
-            ref[join(dt.mirror_dir, 'linux-aarch64')]['a-1.0-0.tar.bz2']['md5'],
+            ref[join(dt.mirror_dir, 'linux-64')]['a-1.0-0.tar.bz2']['md5'],
             EMPTY_MD5)
 
     def test_get_updates(self):
         self.create_test_repo()
         dt.write_reference()
         self.assertEqual(list(dt.get_updates()), [])
+
+        self.create_test_repo('win-32')
+        lst = sorted(dt.get_updates())
+        self.assertEqual(lst, ['win-32/a-1.0-0.tar.bz2',
+                               'win-32/repodata.json',
+                               'win-32/repodata.json.bz2'])
 
     def test_tar_repo(self):
         self.create_test_repo()

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -58,6 +58,12 @@ def test_verify_all_repos(tmpdir):
     dt.verify_all_repos(dt.mirror_dir)
 
 
+def test_read_no_reference(tmpdir):
+    # tmpdir is empty - join(tmpdir, 'reference.json') does not exist
+    with pytest.raises(dt.NoReferenceError):
+        dt.read_reference()
+
+
 def test_write_and_read_reference(tmpdir):
     create_test_repo()
     dt.write_reference(join(tmpdir, 'repo'))


### PR DESCRIPTION
This PR adds the `conda-diff-tar` command to conda-mirror, a tool for creating tarballs from a previous reference point of a conda repository.  The file `diff-tar.md` explains all the details.